### PR TITLE
[bug #162149885] fix when a get return empty

### DIFF
--- a/app/customer/customer_views.py
+++ b/app/customer/customer_views.py
@@ -48,7 +48,10 @@ class GetOrders(Resource):
     @jwt_required
     def get(self):
         orders = Parcel().get_all_orders()
-        return {"orders": [order.serialize() for order in orders]}
+
+        if orders:
+            return {"orders": [order.serialize() for order in orders]}, 200
+        return {"message":"no orders were found"},404
 
 
 class SpecificOrder(Resource):
@@ -72,7 +75,9 @@ class InTransitOrders(Resource):
     def get(self):
 
         orders = Parcel().intransit_orders()
-        return {"In Transitorder": [order.serialize() for order in orders]}
+        if orders:
+            return {"In Transitorder": [order.serialize() for order in orders]}, 200
+        return {"message":"no intransit orders were found"},404
 
 
 class DeclinedOrders(Resource):


### PR DESCRIPTION
## What does this PR do?
 - This PR fixes an instance where we cannot loop through an empty response from the database

## Description of Task to be completed?
 - Fix all the get methods to if and else statements to capture empty returns

